### PR TITLE
add loading screen

### DIFF
--- a/static/game.js
+++ b/static/game.js
@@ -44,6 +44,7 @@ function make_ai_move(){
         $.post('get_ai_move').done(function(data){
             console.log('opponent move:');
             console.log(data);
+            hideLoader();
             $('#loc'+data['location']).removeClass('move_location');
             $('#loc'+data['location']).addClass(move_color + 'stone');
             flip_color()
@@ -70,6 +71,7 @@ function make_ai_move(){
 function click_handler(e){
     if (clickable){
         disable_clicking();
+        showLoader();
         $('.hintstone').removeClass('hintstone');
 
         let square = this;
@@ -142,8 +144,19 @@ function clear_board(){
     move_color = "black";
 }
 
-$().ready(function(){
 
+// Function to show the loader
+function showLoader() {
+    document.getElementById('ai-loader').style.display = 'block';
+}
+
+// Function to hide the loader
+function hideLoader() {
+    document.getElementById('ai-loader').style.display = 'none';
+}
+
+$().ready(function(){
+    hideLoader();
     window.addEventListener( "pageshow", function ( event ) {
         var historyTraversal = event.persisted ||
             ( typeof window.performance != "undefined" &&
@@ -210,6 +223,7 @@ $().ready(function(){
     if (move_color == "white"){
         disable_clicking();
         make_ai_move();
+        hideLoader();
     }
 
 });

--- a/templates/control.html
+++ b/templates/control.html
@@ -21,24 +21,27 @@
     <button id="new_game_button">Start new game</button>
 </div>
 
-<table class="board">
-    {%for i in range(0, size)%}
-    <tr>
-        {%for j in range(0, size)%}
-            <td>
-                {% if i * size + j in moves and moves[i * size + j] == "black" %}
-		    <div id="loc{{i * size + j}}" class="blackstone"></div>
-                {% elif i * size + j in moves and moves[i * size + j] == "white" %}
-		    <div id="loc{{i * size + j}}" class="whitestone"></div>
-                {% else %}
-                    <div id="loc{{i * size + j}}" class="move_location" 
-			 data-row="{{i}}", data-col="{{j}}"></div>
-                {% endif %}
-            </td>
+<div class="board-container">
+    {% include 'loading.html' %}
+    <table class="board">
+        {%for i in range(0, size)%}
+        <tr>
+            {%for j in range(0, size)%}
+                <td>
+                    {% if i * size + j in moves and moves[i * size + j] == "black" %}
+                <div id="loc{{i * size + j}}" class="blackstone"></div>
+                    {% elif i * size + j in moves and moves[i * size + j] == "white" %}
+                <div id="loc{{i * size + j}}" class="whitestone"></div>
+                    {% else %}
+                        <div id="loc{{i * size + j}}" class="move_location"
+                 data-row="{{i}}", data-col="{{j}}"></div>
+                    {% endif %}
+                </td>
+            {%endfor%}
+        </tr>
         {%endfor%}
-    </tr>
-    {%endfor%}
-</table>
+    </table>
+</div>
 {% endblock %}
 
 {% block footer %}

--- a/templates/delayed.html
+++ b/templates/delayed.html
@@ -39,26 +39,27 @@
 </div>
 
 
-
-
-<table class="board">
-    {%for i in range(0, size)%}
-    <tr>
-        {%for j in range(0, size)%}
-            <td>
-                {% if i * size + j in moves and moves[i * size + j] == "black" %}
-		    <div id="loc{{i * size + j}}" class="blackstone"></div>
-                {% elif i * size + j in moves and moves[i * size + j] == "white" %}
-		    <div id="loc{{i * size + j}}" class="whitestone"></div>
-                {% else %}
-                    <div id="loc{{i * size + j}}" class="move_location" 
-			 data-row="{{i}}", data-col="{{j}}"></div>
-                {% endif %}
-            </td>
+<div class="board-container">
+    {% include 'loading.html' %}
+    <table class="board">
+        {%for i in range(0, size)%}
+        <tr>
+            {%for j in range(0, size)%}
+                <td>
+                    {% if i * size + j in moves and moves[i * size + j] == "black" %}
+                <div id="loc{{i * size + j}}" class="blackstone"></div>
+                    {% elif i * size + j in moves and moves[i * size + j] == "white" %}
+                <div id="loc{{i * size + j}}" class="whitestone"></div>
+                    {% else %}
+                        <div id="loc{{i * size + j}}" class="move_location"
+                 data-row="{{i}}", data-col="{{j}}"></div>
+                    {% endif %}
+                </td>
+            {%endfor%}
+        </tr>
         {%endfor%}
-    </tr>
-    {%endfor%}
-</table>
+    </table>
+</div>
 
 {% endblock %}
 

--- a/templates/immediate.html
+++ b/templates/immediate.html
@@ -24,25 +24,28 @@
 <div id = "new_game_control">
     <button id="new_game_button">Start new game</button>
 </div>
-
-<table class="board">
-    {%for i in range(0, size)%}
-    <tr>
-        {%for j in range(0, size)%}
-            <td>
-                {% if i * size + j in moves and moves[i * size + j] == "black" %}
-		    <div id="loc{{i * size + j}}" class="blackstone"></div>
-                {% elif i * size + j in moves and moves[i * size + j] == "white" %}
-		    <div id="loc{{i * size + j}}" class="whitestone"></div>
-                {% else %}
-                    <div id="loc{{i * size + j}}" class="move_location" 
-			 data-row="{{i}}", data-col="{{j}}"></div>
-                {% endif %}
-            </td>
+<div class="board-container">
+    {% include 'loading.html' %}  <!-- Include the loading component here -->
+    <table class="board">
+        {%for i in range(0, size)%}
+        <tr>
+            {%for j in range(0, size)%}
+                <td>
+                    {% if i * size + j in moves and moves[i * size + j] == "black" %}
+                <div id="loc{{i * size + j}}" class="blackstone"></div>
+                    {% elif i * size + j in moves and moves[i * size + j] == "white" %}
+                <div id="loc{{i * size + j}}" class="whitestone"></div>
+                    {% else %}
+                        <div id="loc{{i * size + j}}" class="move_location"
+                 data-row="{{i}}", data-col="{{j}}"></div>
+                    {% endif %}
+                </td>
+            {%endfor%}
+        </tr>
         {%endfor%}
-    </tr>
-    {%endfor%}
-</table>
+    </table>
+</div>
+
 {% endblock %}
 
 {% block footer %}

--- a/templates/loading.html
+++ b/templates/loading.html
@@ -1,0 +1,46 @@
+<div class="loader-container" id="ai-loader">
+    <div class="loader"></div>
+    <p class="loading-text">AI is thinking...</p>
+</div>
+
+
+<style>
+/* Container for the board */
+.board-container {
+    position: relative;
+    width: 100%;
+    height: 100%;
+}
+
+/* Loader that is centered in the board container */
+.loader-container {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+    z-index: 10; /* Make sure it appears above the board */
+}
+
+.loader {
+    border: 4px solid #f3f3f3;
+    border-top: 4px solid #3498db;
+    border-radius: 50%;
+    width: 50px;
+    height: 50px;
+    animation: spin 2s linear infinite;
+}
+
+/* Animation for the loader */
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+.loading-text {
+    font-size: 16px;
+    color: #3498db;
+    margin-top: 10px;
+}
+
+</style>

--- a/templates/loading.html
+++ b/templates/loading.html
@@ -15,8 +15,8 @@
 /* Loader that is centered in the board container */
 .loader-container {
     position: absolute;
-    top: 50%;
-    left: 50%;
+    top: 53%;
+    left: 51.5%;
     transform: translate(-50%, -50%);
     text-align: center;
     z-index: 10; /* Make sure it appears above the board */

--- a/templates/loading.html
+++ b/templates/loading.html
@@ -12,11 +12,10 @@
     height: 100%;
 }
 
-/* Loader that is centered in the board container */
 .loader-container {
     position: absolute;
-    top: 53%;
-    left: 51.5%;
+    top: 56%;
+    left: 51.3%;
     transform: translate(-50%, -50%);
     text-align: center;
     z-index: 10; /* Make sure it appears above the board */
@@ -29,6 +28,8 @@
     width: 50px;
     height: 50px;
     animation: spin 2s linear infinite;
+    position: relative;
+    left: 25%;
 }
 
 /* Animation for the loader */
@@ -38,7 +39,8 @@
 }
 
 .loading-text {
-    font-size: 16px;
+    font-size: 30px;
+    font-weight: 300;
     color: #3498db;
     margin-top: 10px;
 }

--- a/templates/testing.html
+++ b/templates/testing.html
@@ -14,24 +14,31 @@
     <button id="next_button" hidden>Continue to survey</button>
 </div>
 
-<table class="board">
-    {%for i in range(0, size)%}
-    <tr>
-        {%for j in range(0, size)%}
-            <td>
-                {% if i * size + j in moves and moves[i * size + j] == "black" %}
-		    <div id="loc{{i * size + j}}" class="blackstone"></div>
-                {% elif i * size + j in moves and moves[i * size + j] == "white" %}
-		    <div id="loc{{i * size + j}}" class="whitestone"></div>
-                {% else %}
-                    <div id="loc{{i * size + j}}" class="move_location" 
-			 data-row="{{i}}", data-col="{{j}}"></div>
-                {% endif %}
-            </td>
+<div class="board-container">
+    {% include 'loading.html' %}  <!-- Include the loading component here -->
+    <table class="board">
+        {%for i in range(0, size)%}
+        <tr>
+            {%for j in range(0, size)%}
+                <td>
+                    {% if i * size + j in moves and moves[i * size + j] == "black" %}
+                <div id="loc{{i * size + j}}" class="blackstone"></div>
+                    {% elif i * size + j in moves and moves[i * size + j] == "white" %}
+                <div id="loc{{i * size + j}}" class="whitestone"></div>
+                    {% else %}
+                        <div id="loc{{i * size + j}}" class="move_location"
+                 data-row="{{i}}", data-col="{{j}}"></div>
+                    {% endif %}
+                </td>
+            {%endfor%}
+        </tr>
         {%endfor%}
-    </tr>
-    {%endfor%}
-</table>
+    </table>
+</div>
+
+{% endblock %}
+
+{% block footer %}
 
 
 {% endblock %}


### PR DESCRIPTION

**Description**:
This PR introduces a loading spinner to the Gomoku game board that appears when the AI is processing a move. The spinner will display in the center of the board while the AI is thinking and will disappear once the move is completed.

**Changes**:
- **New `loading.html` component**: A reusable loading spinner HTML component has been added, which includes a spinning circle and a message ("AI is thinking...").
- **CSS styles for loading spinner**: Added CSS to center the loading spinner inside the board and style it for visual clarity.
- **JavaScript functionality**: Updated `game.js` to show the loading spinner when an AI move is being calculated and hide it once the move is finished.
- **Template update**: include the loading spinner and ensure it is displayed inside the board container, rather than as a full-page overlay.

**Why this change is needed**:
- This change provides a visual cue to the player that the AI is actively processing a move, improving user experience and eliminating confusion during the AI's thinking time.
- Keeps the UI dynamic and responsive, making it clear when the game is in a "waiting" state.
![image](https://github.com/user-attachments/assets/f661e78c-128a-43b8-a76c-fe7dc817b4e7)
